### PR TITLE
mpi  operator image fix

### DIFF
--- a/dkube/kustomization.yaml
+++ b/dkube/kustomization.yaml
@@ -94,6 +94,8 @@ secretGenerator:
 images:
   - name: gcr.io/ml-pipeline/frontend
     newName: ocdr/ml-pipeline-ui
+  - name: mpioperator/mpi-operator
+    newName: ocdr/mpi-operator
 
 patches:
 - path: patches/regcred.yaml


### PR DESCRIPTION
Fix for https://github.com/oneconvergence/gpuaas/issues/7841

Use ocdr image for mpi-operator

ocdr/mpi-operator:latest
